### PR TITLE
Re-enable nodegraph crate and get draw_path SDF shader working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,6 +1228,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_reactor_nodegraph"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy_reactor",
+]
+
+[[package]]
 name = "bevy_reflect"
 version = "0.19.0-dev"
 source = "git+https://github.com/cart/bevy.git?branch=next-generation-scenes#fc88caabcb41ebfb1699e4ddaf419db25daaae14"
@@ -2363,6 +2371,7 @@ dependencies = [
  "bevy",
  "bevy_reactor",
  "bevy_reactor_gizmoids",
+ "bevy_reactor_nodegraph",
  "smol_str 0.3.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [workspace]
 # members = ["crates/*"]
-members = ["crates/bevy_reactor"]
+members = ["crates/bevy_reactor", "crates/bevy_reactor_nodegraph"]
 
 [workspace.dependencies]
 # bevy = { version = "0.15.0-dev", features = ["ghost_nodes"] }
@@ -19,7 +19,7 @@ bevy = { git = "https://github.com/cart/bevy.git", version = "0.19.0-dev", branc
 bevy_reactor = { path = "crates/bevy_reactor" }
 # bevy_reactor_formulae = { path = "crates/bevy_reactor_formulae" }
 bevy_reactor_gizmoids = { path = "crates/bevy_reactor_gizmoids" }
-# bevy_reactor_nodegraph = { path = "crates/bevy_reactor_nodegraph" }
+bevy_reactor_nodegraph = { path = "crates/bevy_reactor_nodegraph" }
 # bevy_reactor_prop_inspect = { path = "crates/bevy_reactor_prop_inspect" }
 smol_str = "0.3.2"
 
@@ -29,7 +29,7 @@ bevy = { workspace = true }
 bevy_reactor = { workspace = true }
 # bevy_reactor_formulae = { workspace = true }
 bevy_reactor_gizmoids = { workspace = true }
-# bevy_reactor_nodegraph = { workspace = true }
+bevy_reactor_nodegraph = { workspace = true }
 # bevy_reactor_prop_inspect = { workspace = true }
 smol_str = { workspace = true }
 

--- a/crates/bevy_reactor_nodegraph/src/draw_path.rs
+++ b/crates/bevy_reactor_nodegraph/src/draw_path.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
 use bevy::render::render_resource::*;
-use bevy::render::storage::ShaderStorageBuffer;
+use bevy::render::storage::ShaderBuffer;
 use bevy::shader::ShaderRef;
 
 /// An element within a stroked path.
@@ -94,16 +94,16 @@ pub struct DrawPathMaterial {
 
     /// UI Scale
     #[uniform(2)]
-    pub(crate) scale: f32,
+    pub scale: f32,
 
     /// Path command buffer
     #[storage(3, read_only)]
-    pub(crate) path_commands: Handle<ShaderStorageBuffer>,
+    pub(crate) path_commands: Handle<ShaderBuffer>,
     // pub(crate) commands: Vec<PathCommand>,
 }
 
 impl DrawPathMaterial {
-    pub fn new(path_commands: Handle<ShaderStorageBuffer>) -> Self {
+    pub fn new(path_commands: Handle<ShaderBuffer>) -> Self {
         Self {
             color: Default::default(),
             width: 1.0,
@@ -112,7 +112,7 @@ impl DrawPathMaterial {
         }
     }
 
-    pub fn update(&mut self, path: &DrawablePath, buffers: &mut Assets<ShaderStorageBuffer>) {
+    pub fn update(&mut self, path: &DrawablePath, buffers: &mut Assets<ShaderBuffer>) {
         let bounds = path.bounds();
         self.color = path.color.to_vec4();
         self.width = path.width;

--- a/crates/bevy_reactor_nodegraph/src/graph.rs
+++ b/crates/bevy_reactor_nodegraph/src/graph.rs
@@ -16,7 +16,6 @@ use bevy::{
     },
     feathers::{
         constants::fonts, cursor::EntityCursor, font_styles::InheritableFont, palette,
-        theme::ThemedText,
     },
     input::{ButtonInput, keyboard::KeyCode, mouse::MouseScrollUnit},
     log::{debug, warn_once},
@@ -29,7 +28,8 @@ use bevy::{
         },
         hover::Hovered,
     },
-    render::storage::ShaderStorageBuffer,
+    render::storage::ShaderBuffer,
+    text::FontSize,
     scene2::{Scene, bsn, on, template_value},
     ui::{
         AlignItems, AlignSelf, BackgroundColor, BorderColor, BorderRadius, BoxShadow, ComputedNode,
@@ -112,7 +112,7 @@ pub fn node_graph() -> impl Scene {
             ]},
             // border: UiRect::new(px(0), px(2), px(0), px(2)),
         }
-        EntityCursor::System(bevy::window::SystemCursorIcon::Crosshair)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Crosshair))
         on(on_graph_press)
         on(on_graph_drag_start)
         on(on_graph_drag)
@@ -209,14 +209,14 @@ pub fn node_graph_node_title() -> impl Scene {
             padding: UiRect::axes(px(8.0), px(2.0)),
             border_radius: BorderRadius::new(px(3), px(3), px(0), px(0)),
         }
-        EntityCursor::System(bevy::window::SystemCursorIcon::Move)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Move))
         GraphNodeTitle
         BorderColor::all(Color::WHITE)
         BackgroundColor(palette::ACCENT)
         BorderColor::all(palette::GRAY_3)
         InheritableFont {
             font: fonts::REGULAR,
-            font_size: 12.0,
+            font_size: FontSize::Px(12.0),
         }
     }
 }
@@ -238,10 +238,10 @@ pub fn node_graph_node_body() -> impl Scene {
         }
         BackgroundColor(palette::GRAY_2)
         GraphNodeBody
-        EntityCursor::System(bevy::window::SystemCursorIcon::Default)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Default))
         InheritableFont {
             font: fonts::REGULAR,
-            font_size: 12.0,
+            font_size: FontSize::Px(12.0),
         }
     }
 }
@@ -258,9 +258,9 @@ pub fn input_terminal(color: Color) -> impl Scene {
         }
         InheritableFont {
             font: fonts::REGULAR,
-            font_size: 12.0,
+            font_size: FontSize::Px(12.0),
         }
-        EntityCursor::System(bevy::window::SystemCursorIcon::Pointer)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Pointer))
         [
             Node {
                 position_type: PositionType::Absolute,
@@ -296,9 +296,9 @@ pub fn output_terminal(color: Color) -> impl Scene {
         }
         InheritableFont {
             font: fonts::REGULAR,
-            font_size: 12.0,
+            font_size: FontSize::Px(12.0),
         }
-        EntityCursor::System(bevy::window::SystemCursorIcon::Pointer)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Pointer))
         [
             Node {
                 position_type: PositionType::Absolute,
@@ -341,7 +341,7 @@ pub fn label(text: impl Into<String>) -> impl Scene {
     let text = text.into();
     bsn! {
         Text({text.clone()})
-        ThemedText
+        // TODO: ThemedText doesn't derive Clone, can't use in bsn
     }
 }
 
@@ -408,7 +408,7 @@ pub(crate) fn on_insert_connection(
     q_graph_doc: Query<(&UiTransform, &UiGlobalTransform, &ComputedNode), With<GraphDocument>>,
     q_terminals: Query<(&UiGlobalTransform, &ComputedNode)>,
     mut r_materials: ResMut<Assets<DrawPathMaterial>>,
-    mut r_bindings: ResMut<Assets<ShaderStorageBuffer>>,
+    mut r_bindings: ResMut<Assets<ShaderBuffer>>,
     mut commands: Commands,
 ) {
     if let Ok((connection, mut node, material_node, children)) = q_connection.get_mut(insert.entity)
@@ -477,11 +477,11 @@ pub(crate) fn on_insert_connection(
 
         match material_node {
             Some(material_handle) => {
-                let material = r_materials.get_mut(material_handle).unwrap();
+                let mut material = r_materials.get_mut(material_handle).unwrap();
                 material.update(&path, &mut r_bindings);
             }
             None => {
-                let buffer = r_bindings.add(ShaderStorageBuffer::default());
+                let buffer = r_bindings.add(ShaderBuffer::default());
                 let mut material = DrawPathMaterial::new(buffer);
                 material.update(&path, &mut r_bindings);
                 commands
@@ -565,7 +565,7 @@ pub(crate) fn update_connection_shader(
     mut r_materials: ResMut<Assets<DrawPathMaterial>>,
 ) {
     for (render_target, material_node) in q_node.iter_mut() {
-        let material = r_materials.get_mut(material_node).unwrap();
+        let mut material = r_materials.get_mut(material_node).unwrap();
         material.scale = 1.0 / render_target.scale_factor();
     }
 }

--- a/crates/bevy_reactor_nodegraph/src/scrolling.rs
+++ b/crates/bevy_reactor_nodegraph/src/scrolling.rs
@@ -18,7 +18,7 @@ use bevy::{
         hover::Hovered,
     },
     reflect::{Reflect, prelude::ReflectDefault},
-    scene2::{Scene, bsn, on},
+    scene2::{Scene, bsn, on, template_value},
     ui::{
         AlignSelf, BackgroundColor, BorderRadius, ComputedNode, ComputedUiRenderTargetInfo,
         JustifySelf, Node, PositionType, UiGlobalTransform, UiRect, UiScale, Val, ZIndex, px,
@@ -37,7 +37,7 @@ pub fn node_graph_scrollbar(orientation: ControlOrientation) -> impl Scene {
         GraphScrollbar {
             orientation: orientation
         }
-        EntityCursor::System(bevy::window::SystemCursorIcon::Default)
+        template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Default))
         ZIndex(10)
         on(scrollbar_on_track_press)
         [
@@ -53,7 +53,7 @@ pub fn node_graph_scrollbar(orientation: ControlOrientation) -> impl Scene {
             GraphScrollbarThumb
             BackgroundColor(palette::GRAY_2)
             Hovered::default()
-            EntityCursor::System(bevy::window::SystemCursorIcon::Pointer)
+            template_value(EntityCursor::System(bevy::window::SystemCursorIcon::Pointer))
             on(on_change_hover)
             // on(on_change_dragging)
             on(scrollbar_thumb_on_thumb_press)

--- a/examples/graph_edge.rs
+++ b/examples/graph_edge.rs
@@ -1,55 +1,131 @@
-//! Example which demonstrates drawing of node paths.
+//! Example which demonstrates drawing of node paths using the SDF shader.
 
 use bevy::{
     prelude::*,
-    scene2::{CommandsSpawnScene, bsn},
+    render::storage::ShaderBuffer,
+    ui::ComputedUiRenderTargetInfo,
+    ui_render::prelude::MaterialNode,
 };
-use bevy_reactor::ReactorPlugin;
-use bevy_reactor_nodegraph::ReactorNodeGraphPlugin;
+use bevy_reactor_nodegraph::{DrawPathMaterial, DrawablePath, ReactorNodeGraphPlugin};
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            ReactorPlugin,
             ReactorNodeGraphPlugin,
         ))
         .add_systems(Startup, setup_view_root)
+        .add_systems(PostUpdate, update_scale)
         .add_systems(Update, close_on_esc)
         .run();
 }
 
-// const DOT_IMAGE: &str = "embedded://bevy_reactor_nodegraph/assets/dot.png";
-
-fn setup_view_root(asset_server: Res<AssetServer>, mut commands: Commands) {
-    let image = asset_server.load("embedded://bevy_reactor_nodegraph/assets/dot.png");
-
+fn setup_view_root(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<DrawPathMaterial>>,
+    mut buffers: ResMut<Assets<ShaderBuffer>>,
+) {
     commands.spawn((Camera::default(), Camera2d));
-    commands.spawn_scene(bsn!(
-        (Node {
+
+    // Path 1: S-curve using quadratic beziers (green)
+    let mut path1 = DrawablePath::new(Srgba::new(0.2, 0.8, 0.4, 1.0), 3.0);
+    path1.move_to(Vec2::new(10.0, 10.0));
+    path1.quadratic_to(Vec2::new(90.0, 10.0), Vec2::new(90.0, 70.0));
+    path1.quadratic_to(Vec2::new(90.0, 130.0), Vec2::new(10.0, 130.0));
+
+    spawn_path(
+        &mut commands, &mut materials, &mut buffers,
+        &path1, Vec2::new(50.0, 30.0),
+    );
+
+    // Path 2: Straight line segments (red)
+
+    let mut path2 = DrawablePath::new(Srgba::new(0.9, 0.2, 0.2, 1.0), 2.0);
+    path2.move_to(Vec2::new(0.0, 0.0));
+    path2.line_to(Vec2::new(100.0, 50.0));
+    path2.line_to(Vec2::new(200.0, 0.0));
+    path2.line_to(Vec2::new(300.0, 50.0));
+
+    spawn_path(
+        &mut commands, &mut materials, &mut buffers,
+        &path2, Vec2::new(50.0, 200.0),
+    );
+
+    // Path 3: Connection-style curve (blue) - mimics node graph connection
+    let src = Vec2::new(10.0, 50.0);
+    let dst = Vec2::new(250.0, 120.0);
+    let dx = (dst.x - src.x).abs().mul_add(0.0, (dst.x - src.x).abs() * 0.3).min(20.);
+    let src1 = src + Vec2::new(dx, 0.);
+    let dst1 = dst - Vec2::new(dx, 0.);
+
+    let mut path3 = DrawablePath::new(Srgba::new(0.3, 0.5, 1.0, 1.0), 2.5);
+    path3.move_to(src);
+
+    let mlen = src1.distance(dst1);
+    if mlen > 40. {
+        let src2 = src1.lerp(dst1, 20. / mlen);
+        let dst2 = src1.lerp(dst1, (mlen - 20.) / mlen);
+        path3.quadratic_to(src1, src2);
+        path3.line_to(dst2);
+        path3.quadratic_to(dst1, dst);
+    } else {
+        let mid = src1.lerp(dst1, 0.5);
+        path3.quadratic_to(src1, mid);
+        path3.quadratic_to(dst1, dst);
+    }
+
+    spawn_path(
+        &mut commands, &mut materials, &mut buffers,
+        &path3, Vec2::new(50.0, 350.0),
+    );
+
+    // Path 4: Tight quadratic curve (yellow)
+    let mut path4 = DrawablePath::new(Srgba::new(1.0, 0.8, 0.1, 1.0), 2.0);
+    path4.move_to(Vec2::new(0.0, 80.0));
+    path4.quadratic_to(Vec2::new(60.0, 0.0), Vec2::new(120.0, 80.0));
+    path4.quadratic_to(Vec2::new(180.0, 160.0), Vec2::new(240.0, 80.0));
+
+    spawn_path(
+        &mut commands, &mut materials, &mut buffers,
+        &path4, Vec2::new(50.0, 530.0),
+    );
+}
+
+fn spawn_path(
+    commands: &mut Commands,
+    materials: &mut Assets<DrawPathMaterial>,
+    buffers: &mut Assets<ShaderBuffer>,
+    path: &DrawablePath,
+    offset: Vec2,
+) {
+    let bounds = path.bounds();
+
+    let buffer = buffers.add(ShaderBuffer::default());
+    let mut material = DrawPathMaterial::new(buffer);
+    material.update(path, buffers);
+
+    commands.spawn((
+        Node {
             position_type: PositionType::Absolute,
-            left: px(0),
-            right: px(0),
-            top: px(0),
-            bottom: px(0),
-        }
-        ImageNode {
-            color: Color::srgba(0.2, 0.2, 0.4, 1.0),
-            image: {image.clone()},
-            image_mode: NodeImageMode::Tiled {
-                tile_x: true,
-                tile_y: true,
-                stretch_value: 0.5,
-            },
-        }
-        BackgroundColor(Srgba::new(0.1, 0.1, 0.2, 1.0))
-        // [Connection {
-        //     src_pos: Vec2::new(10.0, 10.0),
-        //     dst_pos: Vec2::new(180.0, 135.0),
-        //     color: Color::srgb(1.0, 0.0, 0.0),
-        // }]
-        )
+            left: Val::Px(offset.x + bounds.min.x),
+            top: Val::Px(offset.y + bounds.min.y),
+            width: Val::Px(bounds.width()),
+            height: Val::Px(bounds.height()),
+            ..default()
+        },
+        MaterialNode(materials.add(material)),
     ));
+}
+
+fn update_scale(
+    q_node: Query<(&ComputedUiRenderTargetInfo, &MaterialNode<DrawPathMaterial>)>,
+    mut materials: ResMut<Assets<DrawPathMaterial>>,
+) {
+    for (render_target, material_node) in q_node.iter() {
+        if let Some(mut material) = materials.get_mut(material_node) {
+            material.scale = 1.0 / render_target.scale_factor();
+        }
+    }
 }
 
 pub fn close_on_esc(input: Res<ButtonInput<KeyCode>>, mut exit: MessageWriter<AppExit>) {


### PR DESCRIPTION
Re-enables bevy_reactor_nodegraph, fixes compilation against current Bevy, and adds a standalone graph_edge example for testing the SDF path shader.